### PR TITLE
Make Bigstring_unix independent of Bigstring

### DIFF
--- a/bigstring-unix.opam
+++ b/bigstring-unix.opam
@@ -14,9 +14,7 @@ build: [
 ]
 depends: [
   "dune" {>= "1.1"}
-  "bigstring"
   "base-bigarray"
-  "base-bytes"
   "base-unix"
   "ocaml" {>= "4.03.0"}
 ]

--- a/src/bigstring_unix.ml
+++ b/src/bigstring_unix.ml
@@ -1,6 +1,8 @@
 
 (* This file is free software, copyright Simon Cruanes. See file "LICENSE" for more details. *)
 
+type t = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+
 (** {2 Memory-map} *)
 
 let map_file_descr ?pos ?(shared=false) fd len =

--- a/src/bigstring_unix.mli
+++ b/src/bigstring_unix.mli
@@ -1,11 +1,16 @@
 
 (* This file is free software, copyright Simon Cruanes. See file "LICENSE" for more details. *)
 
+type t = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+(** This is equivalent to [Bigstring.t]. It is redifined here to avoid depending
+    on [Bigstring].
+    @since 0.3 *)
+
 (** {2 Memory-map} *)
 
 val with_map_file :
   ?pos:int64 -> ?len:int -> ?mode:int -> ?flags:open_flag list -> ?shared:bool ->
-  string -> (Bigstring.t -> 'a) -> 'a
+  string -> (t -> 'a) -> 'a
 (** [with_map_file name f] maps the file into memory, opening it, and
     call [f] with a slice [pos.... pos+len] of the bytes of the file
     where [len] is the length of the file if not provided.
@@ -17,7 +22,7 @@ val with_map_file :
     @param flags opening flags (default rdonly)
     see {!Bigarray.Array1.map_file} for more details *)
 
-val map_file_descr : ?pos:int64 -> ?shared:bool -> Unix.file_descr -> int -> Bigstring.t
+val map_file_descr : ?pos:int64 -> ?shared:bool -> Unix.file_descr -> int -> t
 (** [map_file_descr descr len] is a lower-level access to an underlying file descriptor.
     @param shared if true, modifications are shared between processes that
     have mapped this file (requires the filedescr to be open in write mode).

--- a/src/dune
+++ b/src/dune
@@ -20,4 +20,4 @@
  (modules Bigstring_compat Bigstring_unix)
  (flags :standard -warn-error -3) ; deprecation
  (synopsis "Bigstrings from Unix memory mapping.")
- (libraries bigstring unix))
+ (libraries bigarray unix))


### PR DESCRIPTION
also remove the unnecessary dependency on base-bytes